### PR TITLE
refetch every 30s when we have exhausted the posts

### DIFF
--- a/src/components/Home/Main.tsx
+++ b/src/components/Home/Main.tsx
@@ -89,9 +89,9 @@ const Main: FC<MainProps> = ({ origin, triggerRefetch, onTriggerRefetchChange })
   }, [triggerRefetch])
 
   // refresh every 30s when post has reached the end and there is no pending quiz
-  setTimeout(function(){ if(!hasNextPage) {
-    router.push('/');
-  }}, 30000);
+  if (data?.pages[0]?.items[0]?.type === 'Quiz' && data?.pages[0]?.items[0]?.quizzes?.length == 0) {
+    setTimeout(function () { router.push('/'); }, 30000);
+  }
 
   return (
     <div className="flex-grow"><>

--- a/src/components/Home/Main.tsx
+++ b/src/components/Home/Main.tsx
@@ -88,6 +88,11 @@ const Main: FC<MainProps> = ({ origin, triggerRefetch, onTriggerRefetchChange })
     router.push('/');
   }, [triggerRefetch])
 
+  // refresh every 30s when post has reached the end and there is no pending quiz
+  setTimeout(function(){ if(!hasNextPage) {
+    router.push('/');
+  }}, 30000);
+
   return (
     <div className="flex-grow"><>
       {

--- a/src/server/router/post.ts
+++ b/src/server/router/post.ts
@@ -111,17 +111,19 @@ export const postRouter = createRouter()
       // get the quizzes
       let quizzes: Quiz[];
 
-      const viewedFeeds = await prisma.feed.findMany({
+      const progress = await prisma.progress.findMany({
         where: {
-          userId: session?.user?.id as string,
-          viewed: true,
+          userId : session?.user?.id as string,
+          nextEvaluate: {
+            lt: new Date()
+          }
         },
         select: {
-          quizId: true
+          quizId: true,
         }
       });
 
-      const quizIdArr = viewedFeeds.map((feed) => feed.quizId);
+      const quizIdArr = progress.map((q) => q.quizId);
 
       // quizzes for the viewed feeds
       quizzes = await prisma.quiz.findMany({

--- a/src/server/router/progress.ts
+++ b/src/server/router/progress.ts
@@ -268,8 +268,9 @@ export const progressRouter = createRouter()
           }
         }
       } else {
-        // Quiz correct -> posts will not appear in the feeds
-        // delete feeds for the quiz, the feeds will be generated if they fail a quiz again
+        // Quiz correct -> posts should be filtered out in the feeds
+        // the quizzes will still be given by selecting from the progress table in regards to the evaluation time
+        // Here, we delete feeds for the quiz, the feeds will be populated only if they fail a quiz again
         const relatedPosts = await prisma.post.findMany({
           where: {
             quizId: input.quizId


### PR DESCRIPTION
1. If the feed is empty (aka. no post nor quiz), refetch every 30 seconds
2. Fetch the quizzes based on the progress, instead of whether the posts are viewed or not.